### PR TITLE
Fix wildcarding not working properly against content with asterisks

### DIFF
--- a/src/stringSimilarity.js
+++ b/src/stringSimilarity.js
@@ -8,10 +8,10 @@ export default (source, target) => {
   if (!source || (source || '') === (target || '')) {
     return source === target;
   }
-
+  const asteriskEscapedTarget = target && target.replace(new RegExp(escapeRegExp('*'), 'g'), '\\*');
   const wildcardedSource = source
     .replace(new RegExp(escapeRegExp('*'), 'g'), '\\*')
     .replace(new RegExp(escapeRegExp(WILDCARD_MARKER_ESCAPED), 'g'), '*');
 
-  return matcher.isMatch(target, wildcardedSource);
+  return matcher.isMatch(asteriskEscapedTarget, wildcardedSource);
 };

--- a/src/stringSimilarity.test.js
+++ b/src/stringSimilarity.test.js
@@ -50,4 +50,16 @@ describe('stringSimilarity', () => {
   it('should not match if the source and target are undefined and null', () => {
     expect(stringSimilarity(null, 'something')).toBe(false);
   });
+
+  it('should match a target with asterisks against a wildcarded source', () => {
+    expect(stringSimilarity(`Some ${WILDCARD} with asterisks ***`, 'Some text with asterisks ***')).toBe(true);
+  });
+
+  it('should not match target with asterisk within a char group against a wildcarded source without asterisk', () => {
+    expect(stringSimilarity(`This ${WILDCARD} a t*`, 'This is a test')).toBe(false);
+  });
+
+  it('should match a target against a source that wildcards the asterisks within the target', () => {
+    expect(stringSimilarity(`These are asterisks: ${WILDCARD}`, 'These are asterisks: ***')).toBe(true);
+  });
 });


### PR DESCRIPTION
**Problem:**
When a target with unescaped asterisks is matched against a source with escaped asterisks, the source asterisks that are escaped will not match with the asterisks in the target, since `'\\*' != '*'`.  Within the source, asterisks not within the wildcard structure `{{*}}` must be escaped so they may be ignored by the Matcher object, but will not match with the original unescaped asterisks that they are intended to match.
**Solution:**
Escape the asterisks within the target as well so `'\\*' == '\\*'`.  Avoid breaking other functionality by checking if the target is undefined or null before generating a new string containing escaped asterisks.
Several tests were added to make sure regular asterisks could be matched, and they did not function as special characters within the Matcher.